### PR TITLE
Change Default Chunk Size

### DIFF
--- a/revengai/conf/default_conf.json
+++ b/revengai/conf/default_conf.json
@@ -1,5 +1,5 @@
 {
-  "chunk_size": 6,
+  "chunk_size": 500,
   "max_workers": 4,
   "auto_sync": false,
   "func_type": false,


### PR DESCRIPTION
This change introduces a change in the `revengai/conf/default_conf.json` file to change the chunk size from 8 to 500 due to from recent upgrades.