### PR TITLE
fix(PLU-257): use Qt-compat Signal alias to support PyQt5

### DIFF
--- a/reai_toolkit/app/components/tabs/similarity_tab.py
+++ b/reai_toolkit/app/components/tabs/similarity_tab.py
@@ -7,7 +7,7 @@ from loguru import logger
 
 from revengai.models.matched_function import MatchedFunction
 
-from reai_toolkit.app.core.qt_compat import QtCore, QtGui, QtWidgets
+from reai_toolkit.app.core.qt_compat import QtCore, QtGui, QtWidgets, Signal
 
 
 TAB_TITLE = "RevEng.AI — Function Similarity"
@@ -22,7 +22,7 @@ class SimilarityTableColumns(IntEnum):
 
 
 class ButtonDelegate(QtWidgets.QStyledItemDelegate):
-    clicked = QtCore.Signal(QtCore.QModelIndex)
+    clicked = Signal(QtCore.QModelIndex)
 
     def __init__(self, parent=None) -> None:
         super().__init__(parent)


### PR DESCRIPTION
## Summary
- Fixes #109 — `ButtonDelegate` in `similarity_tab.py` referenced `QtCore.Signal`, which only exists under PySide6 and raises `AttributeError` on PyQt5 (the binding IDA Pro 9.1 ships with), preventing the plugin from loading.
- Switched to the `Signal` alias already exported by `reai_toolkit.app.core.qt_compat`, which resolves to `QtCore.pyqtSignal` on PyQt5 and `QtCore.Signal` on PySide6.